### PR TITLE
fix: adjust call depth on log.Caller

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ type AppLogger struct {
 func GetLogger(logLevel string) AppLogger {
 	var logger log.Logger
 	logger = log.NewLogfmtLogger(os.Stderr)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.DefaultCaller)
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(6))
 
 	// logLevel should be set to "debug", "info", "warn", or "error"
 	if !slices.Contains([]string{DEBUG, INFO, WARN, ERROR}, logLevel) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,6 +16,7 @@ const (
 	INFO  = "info"
 	WARN  = "warn"
 	ERROR = "error"
+	DEPTH = 6 // DEPTH set to 6 so logger.Error() or similar returns the caller of said function
 )
 
 type AppLogger struct {
@@ -25,7 +26,7 @@ type AppLogger struct {
 func GetLogger(logLevel string) AppLogger {
 	var logger log.Logger
 	logger = log.NewLogfmtLogger(os.Stderr)
-	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(6))
+	logger = log.With(logger, "ts", log.DefaultTimestampUTC, "caller", log.Caller(DEPTH))
 
 	// logLevel should be set to "debug", "info", "warn", or "error"
 	if !slices.Contains([]string{DEBUG, INFO, WARN, ERROR}, logLevel) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -1,0 +1,30 @@
+package logger_test
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rddl-network/go-utils/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLogCaller(t *testing.T) {
+	r, w, err := os.Pipe()
+	assert.NoError(t, err)
+
+	os.Stderr = w
+
+	l := logger.GetLogger(logger.DEBUG)
+	l.Error("msg", "this is an error")
+
+	w.Close()
+
+	stdErrOutput, err := io.ReadAll(r)
+	assert.NoError(t, err)
+
+	stdErrOutputStr := string(stdErrOutput)
+	callerStr := strings.Split(stdErrOutputStr, " ")[1]
+	assert.Equal(t, "caller=logger_test.go:20", callerStr)
+}


### PR DESCRIPTION
fix call depth on log.caller so we can better check where a log message comes from